### PR TITLE
Enabling java 8 compatibility for latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.vaadin.componentfactory</groupId>
 	<artifactId>tooltip-root</artifactId>
 	<packaging>pom</packaging>
-	<version>2.0.3</version>
+	<version>22.0.0</version>
 	<name>Tooltip Root</name>
 	<inceptionYear>2018</inceptionYear>
 	

--- a/tooltip-demo/pom.xml
+++ b/tooltip-demo/pom.xml
@@ -9,7 +9,7 @@
 
     <name>Tooltip Demo</name>
 
-    <version>2.0.3</version>
+    <version>22.0.0</version>
     <inceptionYear>2018</inceptionYear>
     <organization>
         <name>Vaadin Ltd</name>
@@ -18,9 +18,9 @@
 
     <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
-        <vaadin.version>23.0.12</vaadin.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <vaadin.version>22.1.2</vaadin.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -74,13 +74,13 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-component-demo-helpers</artifactId>
-            <version>${vaadin.version}</version>
+            <artifactId>flow-component-demo-helpers</artifactId>
+            <version>9.0.26</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin.componentfactory</groupId>
             <artifactId>tooltip</artifactId>
-            <version>2.0.3</version>
+            <version>22.0.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/tooltip/pom.xml
+++ b/tooltip/pom.xml
@@ -8,7 +8,7 @@
 
     <name>Tooltip</name>
 
-    <version>2.0.3</version>
+    <version>22.0.0</version>
     <inceptionYear>2018</inceptionYear>
     
 	<parent>
@@ -24,10 +24,10 @@
     </organization>
 
     <properties>
-        <vaadin.version>23.0.7</vaadin.version>
+        <vaadin.version>22.1.2</vaadin.version>
         <!-- <testbench.version>6.0.1</testbench.version> -->
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>


### PR DESCRIPTION
This PR makes changes to make the latest tooltip component version, compatible with Java 8. 