### PR TITLE
Tootltip to use vcf-tooltip version for Vaadin 22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.vaadin.componentfactory</groupId>
 	<artifactId>tooltip-root</artifactId>
 	<packaging>pom</packaging>
-	<version>22.0.0</version>
+	<version>22.0.1</version>
 	<name>Tooltip Root</name>
 	<inceptionYear>2018</inceptionYear>
 	

--- a/tooltip-demo/pom.xml
+++ b/tooltip-demo/pom.xml
@@ -9,7 +9,7 @@
 
     <name>Tooltip Demo</name>
 
-    <version>22.0.0</version>
+    <version>22.0.1</version>
     <inceptionYear>2018</inceptionYear>
     <organization>
         <name>Vaadin Ltd</name>
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>com.vaadin.componentfactory</groupId>
             <artifactId>tooltip</artifactId>
-            <version>22.0.0</version>
+            <version>22.0.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/tooltip/pom.xml
+++ b/tooltip/pom.xml
@@ -8,7 +8,7 @@
 
     <name>Tooltip</name>
 
-    <version>22.0.0</version>
+    <version>22.0.1</version>
     <inceptionYear>2018</inceptionYear>
     
 	<parent>

--- a/tooltip/src/main/java/com/vaadin/componentfactory/Tooltip.java
+++ b/tooltip/src/main/java/com/vaadin/componentfactory/Tooltip.java
@@ -44,7 +44,7 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  */
 @Tag("vcf-tooltip")
-@NpmPackage(value = "@vaadin-component-factory/vcf-tooltip", version = "23.0.5")
+@NpmPackage(value = "@vaadin-component-factory/vcf-tooltip", version = "22.0.0")
 @JsModule("@vaadin-component-factory/vcf-tooltip/src/vcf-tooltip.js")
 public class Tooltip extends Component implements HasComponents, HasStyle, HasTheme {
 


### PR DESCRIPTION
This PR updates the vcf-tooltip version to the newly created version for Vaadin 22. 